### PR TITLE
docker: fix warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.12
 RUN useradd -m user
 USER user
 WORKDIR /home/user/tp
-ENV PATH /home/user/.local/bin:$PATH
-CMD jupyter lab --no-browser --ip='*'
+ENV PATH=/home/user/.local/bin:$PATH
+CMD ["jupyter", "lab", "--no-browser", "--ip='*'"]
 
 ADD --chown=user . .
 RUN git remote set-url origin https://github.com/gepetto/supaero2024


### PR DESCRIPTION
Fixed:

```
2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 6)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 7)
 ```